### PR TITLE
Upgrade @vitejs/plugin-vue and add testing mode to enable sourcemaps for proper code coverage

### DIFF
--- a/.env.testing
+++ b/.env.testing
@@ -1,0 +1,1 @@
+NODE_ENV=production

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
         env:
           CYPRESS_MAP_TILE_COMPARE_HOST: http://localhost:5000/
         with:
-          build: npm run build
+          build: npm run build:test
           start: npm run serve
           command: npm run test:e2e
       - name: Upload coverage to Codecov

--- a/README.md
+++ b/README.md
@@ -104,8 +104,11 @@ $ npm run lint
 To run end to end tests, in one console run:
 
 ```console
+$ npm run build:test
 $ npm run serve
 ```
+
+`build:test` will build the app with sourcemaps, which will allow for code coverage later. 
 
 Then in a different console, run:
 
@@ -114,9 +117,9 @@ $ export CYPRESS_MAP_TILE_COMPARE_HOST='http://localhost:5000/'
 $ npm run test:e2e
 ```
 
-This should also generate code coverage automatically, which can be viewed in `coverage/`.
+Code coverage will be generated automatically, and can be viewed in `coverage/`.
 
-To see the cypress tests actually running, run:
+To see the cypress tests actually running in a browser, run:
 
 ``` console
 $ npx cypress open

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@types/geojson": "^7946.0.8",
         "@typescript-eslint/eslint-plugin": "^4.31.1",
         "@typescript-eslint/parser": "^4.31.1",
-        "@vitejs/plugin-vue": "^1.6.0",
+        "@vitejs/plugin-vue": "^1.8.0",
         "@vue/compiler-sfc": "^3.2.12",
         "@vue/eslint-config-airbnb": "^5.3.0",
         "@vue/eslint-config-typescript": "^7.0.0",
@@ -3162,15 +3162,16 @@
       }
     },
     "node_modules/@vitejs/plugin-vue": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-1.6.0.tgz",
-      "integrity": "sha512-n3i8htn8pTg9M+kM3cnEfsPZx/6ngInlTroth6fA1LQTJq5aTVQ8ggaE5pPoAy9vCgHPtcaXMzwpldhqRAkebQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-1.8.0.tgz",
+      "integrity": "sha512-vwR5QkJ9wQiOGTHtYHJuwCaWtcyBp1P/pSxGg5j5+OeWawQso7yLktllEPl+zHFSSDE5Xibe41LjVG4lIHizmA==",
       "dev": true,
       "engines": {
         "node": ">=12.0.0"
       },
       "peerDependencies": {
-        "@vue/compiler-sfc": "^3.2.6"
+        "@vue/compiler-sfc": "^3.2.6",
+        "vite": "^2.5.10"
       }
     },
     "node_modules/@volar/code-gen": {
@@ -28546,9 +28547,9 @@
       }
     },
     "@vitejs/plugin-vue": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-1.6.0.tgz",
-      "integrity": "sha512-n3i8htn8pTg9M+kM3cnEfsPZx/6ngInlTroth6fA1LQTJq5aTVQ8ggaE5pPoAy9vCgHPtcaXMzwpldhqRAkebQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-1.8.0.tgz",
+      "integrity": "sha512-vwR5QkJ9wQiOGTHtYHJuwCaWtcyBp1P/pSxGg5j5+OeWawQso7yLktllEPl+zHFSSDE5Xibe41LjVG4lIHizmA==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc --noEmit && vite build",
+    "build:test": "vue-tsc --noEmit && vite build --mode=testing",
     "serve": "vite preview",
     "lint": "eslint . --ext .js,.vue,.ts",
     "test:e2e": "npx cypress run"
@@ -20,7 +21,7 @@
     "@types/geojson": "^7946.0.8",
     "@typescript-eslint/eslint-plugin": "^4.31.1",
     "@typescript-eslint/parser": "^4.31.1",
-    "@vitejs/plugin-vue": "^1.6.0",
+    "@vitejs/plugin-vue": "^1.8.0",
     "@vue/compiler-sfc": "^3.2.12",
     "@vue/eslint-config-airbnb": "^5.3.0",
     "@vue/eslint-config-typescript": "^7.0.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import istanbul from 'vite-plugin-istanbul';
 
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   plugins: [
     vue(),
     istanbul({
@@ -14,4 +14,7 @@ export default defineConfig({
       cypress: true,
     }),
   ],
-});
+  build: {
+    sourcemap: mode === 'testing',
+  },
+}));


### PR DESCRIPTION
vitejs/plugin-vue decided to introduce a breaking change for generating source maps in v1.8.0: https://github.com/vitejs/vite/blob/main/packages/plugin-vue/CHANGELOG.md#180-2021-09-18

Specifically, this commit: https://github.com/vitejs/vite/commit/93d9a2d175b1a1e3fe54197856a86887b1dadb74

This meant that code coverage stops working as intended with cypress which depends on source maps.

To fix the issue I created a new "build" mode called `testing` that will include source maps. So to generate a build that contains the source maps one needs to run `npm run build:test`. `npm run build` will generate a build without source maps.